### PR TITLE
Force fields to be single-valued or arrays in JsonIndexer

### DIFF
--- a/conf/index-writers.xml.template
+++ b/conf/index-writers.xml.template
@@ -160,7 +160,8 @@
   </writer>
   <writer id="indexer_json_1" class="earth.elio.nutch.indexwriter.json.JsonIndexWriter">
     <parameters>
-      <param name="fields" value="id,url,title,content,tstamp,segment,digest,host,boost"/>
+      <param name="fields.single" value="id,url,title,content,tstamp,segment,digest,host,boost"/>
+      <param name="fields.array" value=""/>
       <param name="base_output_path" value="jsonindexwriter"/>
     </parameters>
     <mapping>

--- a/src/plugin/indexer-json/src/java/earth/elio/nutch/indexwriter/json/JsonConstants.java
+++ b/src/plugin/indexer-json/src/java/earth/elio/nutch/indexwriter/json/JsonConstants.java
@@ -2,10 +2,22 @@ package earth.elio.nutch.indexwriter.json;
 
 public interface JsonConstants {
 
-    String JSON_FIELDS = "fields";
+    /**
+     * The list of fields which will be written out as a single value. If multiple values are encountered,
+     * only the first will be written out.
+     */
+    String SINGLE_FIELDS = "fields.single";
 
-    String FORCE_SINGLE_FIELDS = "force_single";
+    /**
+     * The list of fields which will be written out as an array of strings. If the value is only a
+     * single value, the writer will force it to be an array.
+     */
+    String ARRAY_FIELDS = "fields.array";
 
+    /**
+    * The base output path for the data. Partition information is added to this path to compute
+    * the final path where the data will live.
+    */
     String JSON_BASE_OUTPUT_PATH = "base_output_path";
 
 }


### PR DESCRIPTION
- If there are multiple values for a field that we want to write out as a single-valued field, then we take the first value. If there is a single value for an array field, we force it to be an array.
- fields.single specify which fields should be written as single values and fields.multiple specify which fields should be written as arrays.
- This will maintain a consistent schema for output rows across documents.